### PR TITLE
Fix deploy error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # git-ops - Changelog
 
+## 1.4.1 - 2024-11-22
+
+- Fix missing deploy error reporting
+
 ## 1.4.0 - 2024-02-07
 
 - Add `getDeployableClasses` API for native based tracking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/git-ops",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Library to do git operations to find changed files in a given git repository",
   "author": {
     "name": "Apex Dev Tools Team",

--- a/test/tracking.spec.ts
+++ b/test/tracking.spec.ts
@@ -102,7 +102,7 @@ const mockDeploy = {
     .mockImplementation(() => Promise.resolve(mockDeployResult)),
 };
 
-const mockDeployResult = { done: true };
+const mockDeployResult = { response: { success: true } };
 const mockComponentSet = {
   deploy: jest
     .fn()


### PR DESCRIPTION
If there were deploy errors on `deployAndUpdateSourceTracking` there would be no `logError` calls for these and the call would complete - it does not throw. Now generates errors to pass through the logger.